### PR TITLE
Fix pandas deprecation warning

### DIFF
--- a/DSSATTools/weather.py
+++ b/DSSATTools/weather.py
@@ -97,7 +97,7 @@ class Weather():
         '''
         Initialize a Weather instance. This instance contains the weather data,
         as well as the parameters that define the weather station that the data
-        represents,nsuch as the latitude, longitude and elevation.
+        represents, such as the latitude, longitude and elevation.
 
         Arguments
         ----------
@@ -212,7 +212,7 @@ class Weather():
         ])
         outstr += weather_data_header(self.data.columns)
 
-        df = self.data.applymap(lambda x: f"{x:5.1f}")
+        df = self.data.map(lambda x: f"{x:5.1f}")
         df['day'] = df.index.strftime("%Y%j")
         df = df [["day"]+list(self.data.columns)]
         outstr += "\n".join(map(lambda x: " ".join(x), df.values))

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -6,11 +6,9 @@ import pandas as pd
 import numpy as np
 import shutil
 import os
-import platform
-if 'windows' in platform.system().lower():
-    BASE_PATH = 'C:/Users/daqui/'
-else:
-    BASE_PATH='/home/diego'
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
 
 DATES = pd.date_range('2000-01-01', '2010-12-31')
 N = len(DATES)
@@ -34,7 +32,7 @@ variables={
 
 class TestWeather:  
     def test_write(self):
-        folder = os.path.join(BASE_PATH, 'Py_DSSATTools', 'wth_test')
+        folder = os.path.join(PROJECT_ROOT, 'tests', 'wth_test')
         if os.path.exists(folder): shutil.rmtree(folder)
         wth = Weather(df, variables, 4.54, -75.1, 1800)
         wth.write(folder)


### PR DESCRIPTION
## The Intent of this PR is to fix a `pandas` deprecation warning

#### Changes:
- Fix `DataFrame.applymap` deprecation by replacing with `DataFrame.map` in `weather.py`
- Replace `BASE_PATH` static dir config in `test_weather.py` with OS-agnostic `pathlib.Path`

#### Reason:
Since version 2.1.0 of `pandas`, [`DataFrame.applymap`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.applymap.html) has been deprecated. 
This makes it impossible to run `DSSATTools` on newer versions of `pandas`, as the `DataFrame.applymap` method is used in `weather.py`. Thankfully, it's an easy fix.

Additionally, the `test_weather.py` unit tests were using a hardcoded path. That has been altered to instead find the relative path, to allow the unit tests to be run on any system.

#### Additional Info:
Thank you for making this library open-source @daquinterop. We've been doing some prototyping for running crop models, and this library has been highly useful - and a great time-saver too. The example Jupyter notebooks are a great additional piece of documentation. 
We look forward to making further contributions in the future.
